### PR TITLE
Merge initial Server Status module into master

### DIFF
--- a/tempest_strings.py
+++ b/tempest_strings.py
@@ -95,6 +95,15 @@ MSG_REG_DISABLED = """
     </p>
     """
 
+MSG_REALM_NOTFOUND = """
+    <h2>No realm found on server</h2>
+    <p>
+        Site's owner has no realms in the database. Hit him up to create one.
+    </p>
+    <p>
+        <a href="/">[Return to Main Page]</a>
+    </p>
+    """
 ###
 ### EOF Strings
 ###

--- a/templates/main/server_status.html
+++ b/templates/main/server_status.html
@@ -1,0 +1,20 @@
+{% extends "main_template.html" %}
+
+{% block title %}
+Server Status
+{% end %}
+
+{% block content %}
+    <div id="message">
+        <h2>
+            Server Status
+        </h2>
+        <p>
+            Here you can check upon the status of the server realm!
+        </p>
+        <p>Address: {{ SERVER_STATUS['address'] }}</p>
+        <p>Name: {{ SERVER_STATUS['name'] }}</p>
+        <p>Server is: {{ SERVER_STATUS['status'] }}</p>
+        <p>Server Population: {{ SERVER_STATUS['population'] }}</p> 
+    </div>
+{% end %}


### PR DESCRIPTION
### I have a few points i'd like to discuss / change here:

@berserkingyadis 

1. Is there any particular reason to not to use `self.DATA`?

```python
# Just some convenience
data = self.DATA['serverstatus']

if (data):
    data['name'] = result['name']

<stuff>

# By using self.DATA we avoid train of kwargs and also
# you can later access this data from elsewhere!
self.render("server_status.html", CONFIG=self.CONFIG, DATA=self.DATA)

```

2. Some formatting thing, just a small correction, really:

[Line 362](https://github.com/Levitanious/tempest-cms/compare/server_info#diff-5bc02cefb3ea9e27f1a6776eabd1935dR362): If you want to describe the whole function, better to use string decorator-description like other functions do it -- it has an additional effect of showing up in automated documentation and in IDEs!

---

Apart from these above -- it's a good go to be merged.

Waiting on your feedback.